### PR TITLE
template-generator

### DIFF
--- a/yaml-storm
+++ b/yaml-storm
@@ -3,11 +3,27 @@
 # 
 # Usage:
 # yaml-storm <yaml_file>
-#
+# yaml-storm generate <folder>
 import os
 import sys
 import yaml
 import requests
+
+template = '''url: "https://example.com"
+method: "GET"
+headers:
+  Content-Type: 'application/json'
+data:
+  name: "John Doe"
+  age: 30
+'''
+
+makefile_template = '''.PHONY: request
+request:
+  EXAMPLE="example" \\
+    yaml-storm request.yaml
+'''
+
 
 def help():
     sys.stderr.write("yaml-storm: A simple YAML to CURL converter\n")
@@ -23,12 +39,24 @@ def help():
     sys.stderr.write("data:\n")
     sys.stderr.write("  name: \"John Doe\"\n")
     sys.stderr.write("  age: 30\n")
+    sys.stderr.write("```\n")
+    sys.stderr.write("To generate a YAML file template, use:\n")
+    sys.stderr.write("yaml-storm generate <folder>\n")
+    sys.stderr.write("This will create a folder with a request.yaml file and a Makefile.\n")
     sys.exit(1)
 
 def validateArguments():
-    if len(sys.argv) != 2:
+    if len(sys.argv) < 2:
         return False
+    if sys.argv[1] == 'generate':
+        if len(sys.argv) < 3:
+            return False
     return True
+
+def validateFolderDoesNotExist(folder):
+    if os.path.exists(folder):
+        sys.stderr.write(f"Error: Folder '{folder}' already exists.\n")
+        sys.exit(1)
 
 # Substitute all variables in a file with their environment variable values
 # Format of the variables is {{var_name}}.
@@ -39,11 +67,33 @@ def substituteVariables(file_path):
         data = data.replace(f'{{{{{var}}}}}', os.environ[var])
     return data
 
+# Generate a YAML file if the user requests it
+def generateYaml(file_path):
+    filename = os.path.join(os.path.basename(file_path), 'request.yaml')
+    with open(filename, 'w') as file:
+        file.write(template)
+    sys.stderr.write(f"YAML file created at {filename}\n")
+
+# Generate Makefile
+def generateMakefile(folder):
+    filename = os.path.join(folder, 'Makefile')
+    with open(filename, 'w') as file:
+        file.write(makefile_template)
+    sys.stderr.write(f"Makefile created at {filename}\n")
+
 def main():
     isDebug = os.getenv('DEBUG')
     if not validateArguments():
         help()
         sys.exit(1)
+
+    if sys.argv[1] == 'generate':
+        folder = sys.argv[2]
+        validateFolderDoesNotExist(folder)
+        os.makedirs(folder, exist_ok=False)
+        generateYaml(folder)
+        generateMakefile(folder)
+        sys.exit(0)
 
     yaml_file = sys.argv[1]
 


### PR DESCRIPTION
This pull request enhances the functionality of the `yaml-storm` tool by adding a new `generate` command to create YAML templates and Makefiles, improving argument validation, and updating the help text to reflect the new features.

### New Feature: YAML and Makefile Generation
* Added a `generate` command to create a folder containing a `request.yaml` template and a `Makefile`. The YAML template includes example HTTP request data, and the Makefile provides a command to execute the request. (`yaml-storm`, [[1]](diffhunk://#diff-916c104b072c3b2829b4c99a1dbdfc86e0116b4db75d631b0905d661f1905ae8L6-R27) [[2]](diffhunk://#diff-916c104b072c3b2829b4c99a1dbdfc86e0116b4db75d631b0905d661f1905ae8R70-R97)

### Improved Argument Validation
* Updated `validateArguments` to handle the new `generate` command and ensure appropriate arguments are provided. Added a `validateFolderDoesNotExist` function to prevent overwriting existing folders. (`yaml-storm`, [[1]](diffhunk://#diff-916c104b072c3b2829b4c99a1dbdfc86e0116b4db75d631b0905d661f1905ae8R42-R60) [[2]](diffhunk://#diff-916c104b072c3b2829b4c99a1dbdfc86e0116b4db75d631b0905d661f1905ae8R70-R97)

### Updated Help Text
* Enhanced the `help` function to include usage instructions for the new `generate` command, explaining its purpose and output. (`yaml-storm`, [yaml-stormR42-R60](diffhunk://#diff-916c104b072c3b2829b4c99a1dbdfc86e0116b4db75d631b0905d661f1905ae8R42-R60))