### PR TITLE
Better error handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ install:
 	@echo "Installing dependencies..."
 	@pip3 install -r requirements.txt
 	@echo "Dependencies installed successfully."
-	sudo cp ./yaml-storm ${bin}/yaml-storm
+	@sudo cp ./yaml-storm ${bin}/yaml-storm
 
 .PHONY: test
 test:

--- a/yaml-storm
+++ b/yaml-storm
@@ -116,7 +116,16 @@ def main():
         sys.stderr.write(f"Data: {data}\n")
 
     # Make the request
-    response = requests.request(method, url, headers=headers, json=data)
+    try:
+        response = requests.request(method, url, headers=headers, json=data)
+    except requests.RequestException as error:
+        # Handle error contains "Failed to resolve"
+        if "Failed to resolve" in str(error):
+            sys.stderr.write(f"Error making request to {url}. Please check the URL and your network connection.\n")
+            sys.stderr.write(f"Error: {error}\n")
+        else:
+            sys.stderr.write(f"Error making request: {error}\n")
+        sys.exit(1)
     
     # Print the response
     sys.stderr.write(f"Response from {url}:\n")

--- a/yaml-storm
+++ b/yaml-storm
@@ -119,7 +119,7 @@ def main():
     try:
         response = requests.request(method, url, headers=headers, json=data)
     except requests.RequestException as error:
-        # Handle error contains "Failed to resolve"
+        # Handle error that contains "Failed to resolve"
         if "Failed to resolve" in str(error):
             sys.stderr.write(f"Error making request to {url}. Please check the URL and your network connection.\n")
             sys.stderr.write(f"Error: {error}\n")


### PR DESCRIPTION
This pull request includes improvements to error handling in the `yaml-storm` script and a minor adjustment to the `Makefile` for consistency in command execution. Below are the most important changes:

### Error handling improvements in `yaml-storm`:

* Added a `try-except` block around the HTTP request in the `main()` function to catch `requests.RequestException` errors. Specific handling was added for errors containing "Failed to resolve," providing clearer error messages to the user and exiting the program gracefully. (`yaml-storm`, [yaml-stormR119-R128](diffhunk://#diff-916c104b072c3b2829b4c99a1dbdfc86e0116b4db75d631b0905d661f1905ae8R119-R128))

### Makefile adjustment:

* Updated the `install:` target in the `Makefile` to use `@sudo` for consistency with other commands, suppressing command output unless there's an error. (`Makefile`, [MakefileL8-R8](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L8-R8))