### PR TITLE
Add curl export

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,9 @@ Then run the following command:
 ```bash
 TOKEN="<your_token>" NAME="John Doe" AGE=30 yaml-storm example.yml
 ```
+
+## Curl export
+You can export the request to a curl command by using the curl flag.
+```bash
+TOKEN="<your_token>" NAME="John Doe" AGE=30 yaml-storm curl example.yml
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pyyaml==6.0.2
+curlify==3.0.0

--- a/yaml-storm
+++ b/yaml-storm
@@ -4,10 +4,11 @@
 # Usage:
 # yaml-storm <yaml_file>
 # yaml-storm generate <folder>
+import curlify
 import os
+import requests
 import sys
 import yaml
-import requests
 
 template = '''url: "https://example.com"
 method: "GET"
@@ -81,6 +82,22 @@ def generateMakefile(folder):
         file.write(makefile_template)
     sys.stderr.write(f"Makefile created at {filename}\n")
 
+# Using curlify to generate a curl command from the YAML file
+def generateCurlCommand(yaml_file):
+    cwd = os.getcwd()
+    file_path = os.path.join(cwd, yaml_file)
+
+    raw_content = substituteVariables(file_path)
+    data = yaml.safe_load(raw_content)
+    
+    url = data.get('url')
+    method = data.get('method', 'GET').upper()
+    headers = data.get('headers', {})
+    data = data.get('data', {})
+
+    response = requests.request(method, url, headers=headers, json=data)
+    return curlify.to_curl(response.request)
+  
 def main():
     isDebug = os.getenv('DEBUG')
     if not validateArguments():
@@ -93,6 +110,14 @@ def main():
         os.makedirs(folder, exist_ok=False)
         generateYaml(folder)
         generateMakefile(folder)
+        sys.exit(0)
+    if sys.argv[1] == 'curl':
+        if len(sys.argv) < 3:
+            sys.stderr.write("Error: Please provide a YAML file to convert to CURL.\n")
+            sys.exit(1)
+        yaml_file = sys.argv[2]
+        curl_command = generateCurlCommand(yaml_file)
+        print(curl_command)
         sys.exit(0)
 
     yaml_file = sys.argv[1]

--- a/yaml-storm
+++ b/yaml-storm
@@ -44,6 +44,9 @@ def help():
     sys.stderr.write("To generate a YAML file template, use:\n")
     sys.stderr.write("yaml-storm generate <folder>\n")
     sys.stderr.write("This will create a folder with a request.yaml file and a Makefile.\n")
+    sys.stderr.write("```\n")
+    sys.stderr.write("Generate curl command from YAML file:\n")
+    sys.stderr.write("<vars> yaml-storm curl <file>\n")
     sys.exit(1)
 
 def validateArguments():


### PR DESCRIPTION
This pull request adds a new feature to export requests defined in YAML files as curl commands, along with updates to documentation and help output. The main changes introduce a new `curl` subcommand, update the help message, and add a dependency on the `curlify` library.

**New curl export feature:**

* Added a `curl` subcommand to the CLI, allowing users to generate a curl command from a YAML file by running `<vars> yaml-storm curl <file>`.
* Implemented the `generateCurlCommand` function using the `curlify` library to convert a YAML-defined request into a curl command.
* Updated the help output to include instructions for using the new curl export feature.
* Added documentation in `README.md` describing how to use the curl export feature.

**Dependency updates:**

* Added imports for `curlify` and `requests` to support the new functionality.